### PR TITLE
feat: configuración de analíticas

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -29,6 +29,8 @@ const { description, title, image } = Astro.props;
     <meta property="og:image" content={image} />
     <meta property="twitter:image" content={image} />
 
+    <script defer src="https://analytics.wupp.dev/script.js" data-website-id="bf67b9c0-6b15-4d11-af7b-3c56661b8f2e"></script>
+
     <title>{title ? title + ' | ULP' : 'UGR Lan Party'}</title>
   </head>
   <body>


### PR DESCRIPTION
Como comentamos por el grupo de administración, esta PR/commit introduce analíticas con Umami sef-hosted en analytics.wupp.dev, hosteado y gestionado por @ComicIvans y yo.

Se incluye el script de tracking en el `head` del layout principal con `defer`. Se puede integrar más en profundidad añadiendo eventos personalizados y otras cosas, pero ahora mismo esta PR simplemente lo integra para las analíticas automáticas.