### PR TITLE
Centrar-Correo-En-Footer

### DIFF
--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -7,21 +7,14 @@
   <div class="container mx-auto px-4">
     <div class="grid grid-cols-1 md:grid-cols-3 gap-8 items-center text-center md:text-left">
 
-      <div class="w-full">
-        <a
-          href="/"
-          class="inline-block max-w-[180px]"
-        >
-          <img
-            src="/assets/logo/logo-black.png"
-            alt="logo"
-            class="max-w-full"
-          />
+      <div class="w-full flex flex-col items-center">
+        <a href="/" class="inline-block max-w-[180px]">
+          <img src="/assets/logo/logo-black.png" alt="logo" class="max-w-full block -mb-4" />
         </a>
-        <p class="text-base text-gray-7">
+        <p class="text-base text-gray-7 mr-2">
           <b>ulp@ugr.es</b>
         </p>
-      </div>
+      </div>      
   
       <div class="flex flex-col items-center space-y-4 text-white">
           <div class="flex items-center space-x-1 justify-center md:space-x-4">


### PR DESCRIPTION
Centrado el correo en el Footer de la página:
Antes:
![image](https://github.com/user-attachments/assets/59ead864-aa1e-4047-9f9d-8c7d9985c1bc)

Ahora:
![image](https://github.com/user-attachments/assets/9b5193f0-b1c4-452a-a731-bf028e7e41d8)
