### PR TITLE
Cambiar-Color-Menu-Desplegable-En-Movil

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -66,13 +66,13 @@ const menuitems = [
             class="absolute right-4 top-1/2 block -translate-y-1/2 rounded-lg px-3 py-[6px] ring-primary focus:ring-2 lg:hidden"
           >
             <span
-              class="relative my-[6px] block h-[2px] w-[40px] bg-dark dark:bg-white"
+              class="relative my-[6px] block h-[2px] w-[40px] bg-white"
             ></span>
             <span
-              class="relative my-[6px] block h-[2px] w-[40px] bg-dark dark:bg-white"
+              class="relative my-[6px] block h-[2px] w-[40px] bg-white"
             ></span>
             <span
-              class="relative my-[6px] block h-[2px] w-[40px] bg-dark dark:bg-white"
+              class="relative my-[6px] block h-[2px] w-[40px] bg-white"
             ></span>
           </button>
           <nav


### PR DESCRIPTION
Cambiado el color del menú desplegable para que sea siempre blanco en móvil.
![image](https://github.com/user-attachments/assets/94574e7b-baf8-4293-82f4-7e24f46badfb)
